### PR TITLE
This patch solves unexpected response for the  swagger yaml file we're using.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,11 @@ var createMockServer = function(options, cb) {
       results.resolved.paths = aggregate(results.resolved.paths);
       results.resolved.definitions = aggregate(results.resolved.definitions);
 
-      app.get('/favicon.ico', function(req, res, next) {
+      app.get('/favicon.ico', function(req, res) {
         res.status(404);
       });
 
-      app.get('/', function(req, res, next) {
+      app.get('/', function(req, res) {
         res.json(results.resolved);
       });
 

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ var createMockServer = function(options, cb) {
           middleware.CORS(),
           middleware.parseRequest(),
           middleware.validateRequest(),
+          injectMockResponse(results, options),
           middleware.mock()
         );
 


### PR DESCRIPTION
Consider the following swagger yaml file:
https://gist.github.com/kmsheng/6a4311badc58f4f2ccec4dcf499c529e

There are two problems that bother me for an afternoon.

One is that I was NOT able to get the response specified in swagger file like [this guy](https://github.com/BigstickCarpet/swagger-express-middleware/issues/90).
For example, `PUT /network/vrrp` I expected to get what I defined in `$ref: '#/externalDocs/x-mocks/VrrpSettingExample'`
```
{
  "enable": false,
  "status": false
}
```

But instead, the swagger-express-middleware just mirror my request data to response data.
For example, I sent `PUT` request `{"enable": false}` and I got `{"enable": false}` in response. This unwanted mock behavior sometimes downgrade my developing experience.

To solve this problem, I [design](https://swagger.io/docs/specification/openapi-extensions/) a `x-override-response` property only for `PUT` request to let developer decide when to have customized mock response, if the `x-override-response` is set to true and `examples` property is provided like https://gist.github.com/kmsheng/6a4311badc58f4f2ccec4dcf499c529e#file-sanji-vrrp-ui-yaml-L43

Then I will get the mock server's default response data plus my example data.
For example, mock server output `{"enable": true}` and my example data is
```
{
  "enable": false,
  "status": false
}
```
then I get
```
{
  "enable": true,
  "status": false
}
```
Pretty similar to the process of `Object.assign`, this is good especially for testing a switch UI widget. 

![screen shot 2018-06-01 at 8 29 04 am](https://user-images.githubusercontent.com/880569/40816888-f34991c4-6581-11e8-9d42-2283703e6f31.png)

Second problem is that GET a collection or array DOES NOT output example data which defined in swagger yaml file in `swagger-express-middleware v1.0.0-alpha.12`, my patch will search possible example data to render before `middleware.mock()`

If there's no example provided or found possibly, it will fallback to default behavior of `middleware.mock()`


