### PR TITLE
feat: customize swagger config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ visit http://localhost:8000 a resolved json version would be provided.
     -I, --input <path>  Input Folder (default: current working directory)
     -P, --port <port>   PORT of server (default: 8000)
     -H, --host <host>   HOST of server (default: 0.0.0.0)
+    -F, --filename <filename> Filename (default: index.yaml)
 ```
 

--- a/bin/mockserver
+++ b/bin/mockserver
@@ -12,6 +12,7 @@ program
     path.join(process.cwd()))
   .option('-P, --port <port>', 'PORT of server (default: 8000)', parseInt)
   .option('-H, --host <host>', 'HOST of server (default: 0.0.0.0)')
+  .option('-F, --filename <filename>', 'Filename (default: index.yaml)')
   .parse(process.argv);
 
 debug({
@@ -24,7 +25,8 @@ var createMockServer = require('../');
 createMockServer({
   rootFolderPath: program.input,
   port: program.port,
-  host: program.host
+  host: program.host,
+  filename: program.filename
 }, function() {
   console.log('running...');
 });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var fs = require('fs');
 var app = express();
 var defaultOptions = {
   host: '0.0.0.0',
-  port: process.env.PORT || 8000
+  port: process.env.PORT || 8000,
+  filename: 'index.yaml'
 };
 
 var aggregate = function(data) {
@@ -62,7 +63,7 @@ var injectMockResponse = function (results, options) {
 var createMockServer = function(options, cb) {
   options = _.defaults(options, defaultOptions);
   var doc = YAML.load(
-    fs.readFileSync(options.rootFolderPath + '/index.yaml').toString());
+    fs.readFileSync(options.rootFolderPath + '/' + options.filename).toString());
   var resolveOptions = {
     relativeBase: options.rootFolderPath,
     loaderOptions: {


### PR DESCRIPTION
This patch makes `things-mock-server` not just able to handle `index.yaml` but also other different kinds of filenames. This patch is also beneficial for testing. e.g. testing cg/index.yaml and cg/vrrp.yaml